### PR TITLE
Gracefully handle id parameter if passed as string

### DIFF
--- a/lib/fcm.rb
+++ b/lib/fcm.rb
@@ -165,7 +165,8 @@ class FCM
   end
 
   def build_post_body(registration_ids, options = {})
-    { registration_ids: registration_ids }.merge(options)
+    ids = registration_ids.is_a?(String) ? [registration_ids] : registration_ids
+    { registration_ids: ids }.merge(options)
   end
 
   def build_response(response, registration_ids = [])


### PR DESCRIPTION
Change provides a minor convenience in case a registration id is passed as a string.

Relaxes our code from the responsibility to always pass an array.

Nothing ventured, nothing gained. :metal: