### PR TITLE
Drop json dependency

### DIFF
--- a/fcm.gemspec
+++ b/fcm.gemspec
@@ -22,5 +22,4 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency('httparty')
-  s.add_dependency('json')
 end


### PR DESCRIPTION
`json` is part of Ruby's stdlib as of 1.9.3 and it is unnecessary to add it as a dependency. [Rails did it](https://github.com/rails/rails/pull/23453), so can you.