### PR TITLE
Gemspec: Drop EOL'd property rubyforge_project

### DIFF
--- a/fcm.gemspec
+++ b/fcm.gemspec
@@ -14,8 +14,6 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version     = '>= 2.0.0'
 
-  s.rubyforge_project = "fcm"
-
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }


### PR DESCRIPTION
The RubyGems property rubyforge_project is removed without a replacement.