### PR TITLE
fix: faraday dependency version

### DIFF
--- a/fcm.gemspec
+++ b/fcm.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_runtime_dependency('faraday','0.15.4')
+  s.add_runtime_dependency('faraday', '>= 0.15.4', '< 1.0')
 end


### PR DESCRIPTION
Related with #55

I was not able to install it due to conflict with another gem that uses `faraday`.