### PR TITLE
README: Use SVG CI badge, drop defunct badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Firebase Cloud Messaging (FCM) for Android and iOS
 
-[![Gem Version](https://badge.fury.io/rb/fcm.svg)](http://badge.fury.io/rb/fcm) [![Build Status](https://secure.travis-ci.org/spacialdb/fcm.png?branch=master)](http://travis-ci.org/spacialdb/fcm)
+[![Gem Version](https://badge.fury.io/rb/fcm.svg)](http://badge.fury.io/rb/fcm) [![Build Status](https://secure.travis-ci.org/spacialdb/fcm.svg?branch=master)](http://travis-ci.org/spacialdb/fcm)
 
 The FCM gem lets your ruby backend send notifications to Android and iOS devices via [
 Firebase Cloud Messaging](https://firebase.google.com/docs/cloud-messaging/).
@@ -195,9 +195,3 @@ The guide to set up an iOS app to get notifications is here: [Setting up a FCM C
 ## Many thanks to all the contributors
 
 - [Contributors](https://github.com/spacialdb/fcm/contributors)
-
-## Donations
-
-We accept tips through [Gratipay](https://gratipay.com/spacialdb/).
-
-[![Gratipay](https://img.shields.io/gratipay/spacialdb.svg)](https://www.gittip.com/spacialdb/)


### PR DESCRIPTION
This PR changes the build badges to SVG for sharper readability ✨

Also:

- Gratipay is no longer in service so this PR removes its badge and section