### PR TITLE
Update README.md with Ruby '2.6.5' added as a confirmed version

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ One of the following, tested Ruby versions:
 - `2.3.8`
 - `2.4.5`
 - `2.5.3`
+- `2.6.5`
 
 ## Usage
 


### PR DESCRIPTION
I could confirm this gem works on Ruby 2.6.5