### PR TITLE
Fix "retrieve notification key" query

### DIFF
--- a/lib/fcm.rb
+++ b/lib/fcm.rb
@@ -89,11 +89,7 @@ class FCM
   alias remove remove_registration_ids
 
   def recover_notification_key(key_name, project_id)
-    params = {
-      query: {
-        notification_key_name: key_name
-      }
-    }
+    params = {notification_key_name: key_name}
       
     extra_headers = {
       'project_id' => project_id

--- a/spec/fcm_spec.rb
+++ b/spec/fcm_spec.rb
@@ -472,6 +472,25 @@ describe FCM do
     end # remove context
   end
 
+  describe "#recover_notification_key" do
+    it "sends a 'retrieve notification key' request" do
+      uri = "#{FCM::GROUP_NOTIFICATION_BASE_URI}/gcm/notification"
+      endpoint = stub_request(:get, uri).with(
+        headers: {
+          'Content-Type' => 'application/json',
+          'Authorization' => "key=TEST_SERVER_KEY",
+          'project_id' => "TEST_PROJECT_ID"
+        },
+        query: {notification_key_name: "TEST_KEY_NAME"}
+      )
+      client = FCM.new("TEST_SERVER_KEY")
+
+      client.recover_notification_key("TEST_KEY_NAME", "TEST_PROJECT_ID")
+
+      expect(endpoint).to have_been_requested
+    end
+  end
+
   describe 'subscribing to a topic' do
     # TODO
   end


### PR DESCRIPTION
Before, we were sending the wrong parameters to the "retrieve notification key" endpoint. By submitting invalid arguments, we were causing every request to fail. We fixed the query for the "retrieve notification key" endpoint.